### PR TITLE
fix(beacons): stale asset-queue eviction, connection warmup, and connect retry

### DIFF
--- a/ReserveBlockCore/Models/AssetQueue.cs
+++ b/ReserveBlockCore/Models/AssetQueue.cs
@@ -7,6 +7,8 @@ namespace ReserveBlockCore.Models
 {
     public class AssetQueue
     {
+        public const int StaleTimeoutMinutes = 30;
+
         public int Id { get; set; }
         public string SmartContractUID { get; set; }
         public string FromAddress { get; set; }
@@ -103,20 +105,26 @@ namespace ReserveBlockCore.Models
                 var acRec = aqDB.FindOne(x => x.SmartContractUID == aq.SmartContractUID && x.AssetTransferType == aq.AssetTransferType && x.IsComplete != true);
                 if (acRec != null)
                 {
-                    return false;
+                    var staleCutoff = DateTime.UtcNow.AddMinutes(-StaleTimeoutMinutes);
+                    if (acRec.SubmitDate < staleCutoff)
+                    {
+                        aqDB.DeleteSafe(acRec.Id);
+                        ErrorLogUtility.LogError($"Removed stale incomplete AQ entry while creating new one. SCUID: {acRec.SmartContractUID}, SubmitDate: {acRec.SubmitDate}", "AssetQueue.SaveAssetQueueItem()");
+                    }
+                    else
+                    {
+                        return false;
+                    }
                 }
-                else
+
+                try
                 {
-                    try
-                    {
-                        aqDB.InsertSafe(aq);
-                        return true;
-                    }
-                    catch(Exception ex)
-                    {
-                        ErrorLogUtility.LogError("Failed to saved AQ Item.", "AssetQueue.SaveAssetQueueItem()");
-                    }
-                    
+                    aqDB.InsertSafe(aq);
+                    return true;
+                }
+                catch(Exception ex)
+                {
+                    ErrorLogUtility.LogError("Failed to saved AQ Item.", "AssetQueue.SaveAssetQueueItem()");
                 }
             }
 

--- a/ReserveBlockCore/Program.cs
+++ b/ReserveBlockCore/Program.cs
@@ -646,6 +646,8 @@ namespace ReserveBlockCore
 
             StartupService.LoadBeacons();
             await StartupService.EstablishBeaconReference();
+            StartupService.CleanupStaleAssetQueue();
+            StartupService.WarmUpBeaconConnection();
 
             //Removes validator record from DB_Peers as its now within the wallet.
             StartupService.ClearOldValidatorDups();

--- a/ReserveBlockCore/Services/SmartContractService.cs
+++ b/ReserveBlockCore/Services/SmartContractService.cs
@@ -445,7 +445,22 @@ namespace ReserveBlockCore.Services
                         {
                             await WalletService.SendReserveTransaction(scTx, rAccount, true);
                         }
-                        
+
+                        //Defensive: ensure AQ entry is marked complete on success path.
+                        //BeaconUtility.SendAssets_New already does this when assets > 0, but if
+                        //assets.Count() == 0 or the background marker was interrupted, the entry
+                        //would otherwise stay IsComplete=false and block future transfers.
+                        if (aq != null)
+                        {
+                            var aqLatest = aqDB.FindOne(x => x.Id == aq.Id);
+                            if (aqLatest != null && !aqLatest.IsComplete)
+                            {
+                                aqLatest.IsComplete = true;
+                                aqLatest.IsDownloaded = true;
+                                aqDB.UpdateSafe(aqLatest);
+                            }
+                        }
+
                         SCLogUtility.Log($"TX Success. SCUID: {scMain.SmartContractUID}", "SmartContractService.TransferSmartContract()");
                         return;
                     }

--- a/ReserveBlockCore/Services/StartupService.cs
+++ b/ReserveBlockCore/Services/StartupService.cs
@@ -765,8 +765,60 @@ namespace ReserveBlockCore.Services
                         Globals.Beacons.TryAdd(beacon.IPAddress, beacon);
                     }
                 }
-            }                
+            }
 
+        }
+
+        internal static void WarmUpBeaconConnection()
+        {
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await Task.Delay(5000); //let network settle after startup
+                    if (!Globals.Beacon.Values.Where(x => x.IsConnected).Any())
+                    {
+                        var result = await BeaconUtility.EstablishBeaconConnection(true, false);
+                        if (result)
+                            LogUtility.Log("Beacon connection warmed up at startup.", "StartupService.WarmUpBeaconConnection()");
+                        else
+                            LogUtility.Log("Beacon warmup did not connect. Lazy connect will retry on first request.", "StartupService.WarmUpBeaconConnection()");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    ErrorLogUtility.LogError($"Beacon warmup error: {ex}", "StartupService.WarmUpBeaconConnection()");
+                }
+            });
+        }
+
+        internal static void CleanupStaleAssetQueue()
+        {
+            try
+            {
+                var aqDB = AssetQueue.GetAssetQueue();
+                if (aqDB == null)
+                    return;
+
+                var cutoff = DateTime.UtcNow.AddMinutes(-AssetQueue.StaleTimeoutMinutes);
+                var staleEntries = aqDB.Query()
+                    .Where(x => x.IsComplete != true && x.SubmitDate < cutoff)
+                    .ToList();
+
+                if (staleEntries.Count == 0)
+                    return;
+
+                foreach (var entry in staleEntries)
+                {
+                    aqDB.DeleteSafe(entry.Id);
+                    SCLogUtility.Log($"Removed stale asset queue entry. SCUID: {entry.SmartContractUID}, SubmitDate: {entry.SubmitDate}",
+                        "StartupService.CleanupStaleAssetQueue()");
+                }
+            }
+            catch (Exception ex)
+            {
+                ErrorLogUtility.LogError($"Failed to clean up stale asset queue: {ex}", "StartupService.CleanupStaleAssetQueue()");
+            }
         }
 
         internal static void BootstrapBeacons()

--- a/ReserveBlockCore/Services/StartupService.cs
+++ b/ReserveBlockCore/Services/StartupService.cs
@@ -800,9 +800,14 @@ namespace ReserveBlockCore.Services
                 if (aqDB == null)
                     return;
 
+                //Upload rows only: stale incomplete uploads block new transfers for the same
+                //contract and have no background owner. Download rows belong to the
+                //ClientCallService retry worker (NextAttempt scheduling) — deleting them here
+                //would permanently stop a received asset from downloading.
                 var cutoff = DateTime.UtcNow.AddMinutes(-AssetQueue.StaleTimeoutMinutes);
                 var staleEntries = aqDB.Query()
-                    .Where(x => x.IsComplete != true && x.SubmitDate < cutoff)
+                    .Where(x => x.IsComplete != true && x.SubmitDate < cutoff &&
+                                x.AssetTransferType == AssetQueue.TransferType.Upload)
                     .ToList();
 
                 if (staleEntries.Count == 0)

--- a/ReserveBlockCore/Utilities/BeaconUtility.cs
+++ b/ReserveBlockCore/Utilities/BeaconUtility.cs
@@ -9,26 +9,45 @@ namespace ReserveBlockCore.Utilities
 {
     public class BeaconUtility
     {
+        //Serializes connection establishment: the startup warmup and concurrent transfer
+        //requests all check-then-connect, so without a gate two callers can connect to the
+        //same beacon and overwrite each other's Globals.Beacon entry.
+        private static readonly SemaphoreSlim _connectGate = new SemaphoreSlim(1, 1);
+
         public static async Task<bool> EstablishBeaconConnection(bool upload = false, bool download = false)
         {
-            //A single sweep can fail transiently (beacon restart, post-sleep network, brief
-            //unreachability) and previously failed the whole transfer. Each connect attempt is
-            //capped at 3s inside ConnectBeacon_New, so retrying the sweep stays bounded.
-            const int maxAttempts = 3;
-            for (var attempt = 1; attempt <= maxAttempts; attempt++)
+            await _connectGate.WaitAsync();
+            try
             {
-                if (await TryEstablishBeaconConnectionOnce(upload, download))
+                //Another caller may have connected while we waited on the gate. Every current
+                //call site requests an upload connection after checking IsConnected, so an
+                //existing live connection satisfies the request.
+                if (Globals.Beacon.Values.Where(x => x.IsConnected).Any())
                     return true;
 
-                if (attempt < maxAttempts)
+                //A single sweep can fail transiently (beacon restart, post-sleep network, brief
+                //unreachability) and previously failed the whole transfer. Each connect attempt is
+                //capped at 3s inside ConnectBeacon_New, so retrying the sweep stays bounded.
+                const int maxAttempts = 3;
+                for (var attempt = 1; attempt <= maxAttempts; attempt++)
                 {
-                    LogUtility.Log($"Beacon connection sweep {attempt}/{maxAttempts} failed. Retrying...", "BeaconUtility.EstablishBeaconConnection()");
-                    await Task.Delay(2500);
-                }
-            }
+                    if (await TryEstablishBeaconConnectionOnce(upload, download))
+                        return true;
 
-            ErrorLogUtility.LogError($"Failed to connect to any beacon after {maxAttempts} sweeps. Please ensure you are not blocking outside connections to 3338, 13338, 23338, or 33338.", "BeaconUtility.EstablishBeaconConnection()");
-            return false;
+                    if (attempt < maxAttempts)
+                    {
+                        LogUtility.Log($"Beacon connection sweep {attempt}/{maxAttempts} failed. Retrying...", "BeaconUtility.EstablishBeaconConnection()");
+                        await Task.Delay(2500);
+                    }
+                }
+
+                ErrorLogUtility.LogError($"Failed to connect to any beacon after {maxAttempts} sweeps. Please ensure you are not blocking outside connections to 3338, 13338, 23338, or 33338.", "BeaconUtility.EstablishBeaconConnection()");
+                return false;
+            }
+            finally
+            {
+                _connectGate.Release();
+            }
         }
 
         private static async Task<bool> TryEstablishBeaconConnectionOnce(bool upload, bool download)

--- a/ReserveBlockCore/Utilities/BeaconUtility.cs
+++ b/ReserveBlockCore/Utilities/BeaconUtility.cs
@@ -11,6 +11,28 @@ namespace ReserveBlockCore.Utilities
     {
         public static async Task<bool> EstablishBeaconConnection(bool upload = false, bool download = false)
         {
+            //A single sweep can fail transiently (beacon restart, post-sleep network, brief
+            //unreachability) and previously failed the whole transfer. Each connect attempt is
+            //capped at 3s inside ConnectBeacon_New, so retrying the sweep stays bounded.
+            const int maxAttempts = 3;
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                if (await TryEstablishBeaconConnectionOnce(upload, download))
+                    return true;
+
+                if (attempt < maxAttempts)
+                {
+                    LogUtility.Log($"Beacon connection sweep {attempt}/{maxAttempts} failed. Retrying...", "BeaconUtility.EstablishBeaconConnection()");
+                    await Task.Delay(2500);
+                }
+            }
+
+            ErrorLogUtility.LogError($"Failed to connect to any beacon after {maxAttempts} sweeps. Please ensure you are not blocking outside connections to 3338, 13338, 23338, or 33338.", "BeaconUtility.EstablishBeaconConnection()");
+            return false;
+        }
+
+        private static async Task<bool> TryEstablishBeaconConnectionOnce(bool upload, bool download)
+        {
             var userInputedBeaconsUsed = false;
             var selfBeacon = Globals.SelfBeacon;
             if (selfBeacon?.SelfBeaconActive == true)
@@ -23,7 +45,7 @@ namespace ReserveBlockCore.Utilities
                 }
                 else
                 {
-                    ErrorLogUtility.LogError("There was an issue with your self hosted beacon. Please ensure all ports are open and the beacon is properly configured.", "BeaconUtility.EstablishBeaconConnection()");
+                    ErrorLogUtility.LogError("There was an issue with your self hosted beacon. Please ensure all ports are open and the beacon is properly configured.", "BeaconUtility.TryEstablishBeaconConnectionOnce()");
                     return false;
                 }
             }
@@ -71,7 +93,7 @@ namespace ReserveBlockCore.Utilities
                 return conResult;
             }
 
-            ErrorLogUtility.LogError("Failed to connect to every beacon stored in wallet. Please ensure you are not blocking outside connections to 3338, 13338, 23338, or 33338.", "BeaconUtility.EstablishBeaconConnection()");
+            ErrorLogUtility.LogError("Failed to connect to every beacon stored in wallet. Please ensure you are not blocking outside connections to 3338, 13338, 23338, or 33338.", "BeaconUtility.TryEstablishBeaconConnectionOnce()");
             return false; //something failed if we reach here. This means ZERO connections were made to beacon
         }
 


### PR DESCRIPTION
Fixes NFT/asset transfers getting permanently blocked by stuck incomplete AssetQueue entries, and first-transfer failures from cold beacon connections.

## Changes

**Stale asset-queue handling** (`AssetQueue`, `StartupService`, `SmartContractService`, `Program`)
- `SaveAssetQueueItem`: an incomplete entry for the same SCUID + transfer type older than 30 minutes is evicted and replaced instead of rejecting the new transfer forever.
- `StartupService.CleanupStaleAssetQueue`: startup sweep deleting incomplete entries older than the same cutoff (entries orphaned by shutdown).
- `TransferSmartContract`: defensively marks the upload AQ entry complete after a successful TX broadcast (covers the `assets.Count() == 0` path and interrupted background marking).

**Beacon connection reliability** (`StartupService`, `BeaconUtility`, `Program`)
- `WarmUpBeaconConnection`: fire-and-forget upload-connection warmup 5s after startup when no beacon is connected; lazy connect remains the fallback.
- `EstablishBeaconConnection` now retries the full beacon sweep up to 3 times with a 2.5s pause (each individual connect is already capped at 3s inside `ConnectBeacon_New`, so worst case stays bounded at ~40s). This covers the cold cases the warmup can't: `WithAutomaticReconnect()` gives up permanently after ~42s and the `Closed` handler only logs, so long-running wallets hit their first transfer cold. All 10 lazy-connect call sites inherit the retry.

## Validation

- `SubmitDate` is written with `DateTime.UtcNow` (single assignment site), so the UTC cutoff comparisons are clock-consistent.
- The `ClientCallService` background retry loop only touches **Download** entries; the defensive complete-marking targets the **Upload** entry and runs after each `SendAssets_New` was already awaited — no upload-retry regression path.
- Build 0 errors; SecretPreservation + StateSnapshot + all Beacon suites green (36/36).
- Rebased onto `testnet` (no conflict with the testnet-flag commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6xfaNyD8pXz9cgtquNS46