### PR TITLE
fix(build): exclude Tests project from publish output (wrong-arch FROST lib)

### DIFF
--- a/VerifiedXCore.Tests/VerifiedXCore.Tests.csproj
+++ b/VerifiedXCore.Tests/VerifiedXCore.Tests.csproj
@@ -6,6 +6,12 @@
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
+    <!-- Never include this project in publish output. A solution-level
+         'dotnet publish' otherwise publishes the Tests project into the same
+         output directory as the app, and its copy pass re-resolves the app's
+         RID-conditioned native-lib rules without the RID, shipping the
+         x86-64 libfrost_ffi.so onto arm64 nodes (dead FROST signing). -->
+    <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What
One line: `<IsPublishable>false</IsPublishable>` on `VerifiedXCore.Tests`, so solution-level publishes skip the Tests project.

## Why
A solution-level `dotnet publish` also publishes the Tests project into the same output directory as the app. Its copy pass re-resolves the app's RID-conditioned native-lib rules **without the RuntimeIdentifier applied**, so it ships the x86-64 `libfrost_ffi.so` — overwriting the correct arm lib on `-r linux-arm64` publishes.

This is how the testnet explorer node ended up with a dead FROST stack on 2026-08-12 (boot FFI checks failed; withdrawal signing died at aggregation with `NativeAggregationFailed` / native error -4, recovered by manually copying the arm lib). Anyone building from source at the solution level on an arm64 box hits the same thing.

## Changes
- `VerifiedXCore.Tests/VerifiedXCore.Tests.csproj`: add `IsPublishable=false` with a comment documenting the failure mode. `dotnet test` / `dotnet build` behavior unchanged.

## Testing
Reproduced the failing command shape on this branch with the fix applied:
`dotnet publish -c Release -r linux-arm64 --self-contained false` at solution level →
- only `VerifiedXCore` publishes (no Tests publish pass)
- output `libfrost_ffi.so` is ELF **ARM aarch64**, BuildID `c4b74349` (matches `Frost/linux-arm/`)
- no test assemblies (xunit/Moq) in the output

## Integration Notes
Longer-term, moving the native libs to the standard `runtimes/<rid>/native` layout would let the host resolve per-arch at load time and retire the RID-conditioned copy rules entirely (also covers the portable-publish-on-arm case and the missing-arm-plonk gap). This PR is just the minimal guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLKN4mooYykcM7qioNJDPh